### PR TITLE
Run dotenv config for all environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,9 @@
-if (process.env.NODE_ENV !== 'production') {
-  /* eslint-disable global-require */
-  require('dotenv').config();
-}
-
 const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const socket = require('socket.io');
 const cors = require('cors');
+require('dotenv').config();
 
 const app = express();
 const port = process.env.PORT || 8000;


### PR DESCRIPTION
Originally we intended to only use the dotenv library during
development, but have since configured the application to use it in
production as well.